### PR TITLE
Update README to latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: dangoslen/changelog-enforcer@v1.1.1
+    - uses: dangoslen/changelog-enforcer@v1.4.0
       with:
         changeLogPath: 'CHANGELOG.md'
         skipLabel: 'Skip-Changelog'


### PR DESCRIPTION
I noticed that the latest README.md was still pointing to v1.1.1. I think it should probably point to v1.4.0?