### PR TITLE
Fix GitHub actions annotations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,15 +37,16 @@ jobs:
       - name: create release
         if: ${{ steps.check_release.outputs.missing == 'true' }}
         id: create_release
-        uses: actions/create-release@v1.1.4
+        uses: ncipollo/release-action@v1.14.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: "${{ steps.read-version.outputs.tag }}"
-          release_name: Changelog Enforcer ${{ steps.read-version.outputs.version }}
+          tag: "${{ steps.read-version.outputs.tag }}"
+          name: Changelog Enforcer ${{ steps.read-version.outputs.version }}
           body: ${{ steps.changelog_reader.outputs.changes }} 
           draft: false
           prerelease: false
+          token: ${{ env.GITHUB_TOKEN }}
 
       - name: update major version tag
         if: ${{ steps.check_release.outputs.missing == 'true' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
           echo "missing=$MISSING" >> $GITHUB_OUTPUT
         
       - name: create release
-        if: ${{ steps.check_release.outputs.missing == 'true' }}
+        if: ${{ steps.check_release.outputs.missing != 'true' }}
         id: create_release
         uses: ncipollo/release-action@v1.14.0
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
       - 'releases/v2.3'
       - 'releases/v3.3.0'
       - 'main'
+  pull_request:
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,6 @@ on:
       - 'releases/v2.3'
       - 'releases/v3.3.0'
       - 'main'
-  pull_request:
 
 jobs:
   release:
@@ -36,7 +35,7 @@ jobs:
           echo "missing=$MISSING" >> $GITHUB_OUTPUT
         
       - name: create release
-        if: ${{ steps.check_release.outputs.missing != 'true' }}
+        if: ${{ steps.check_release.outputs.missing == 'true' }}
         id: create_release
         uses: ncipollo/release-action@v1.14.0
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,15 +38,12 @@ jobs:
         if: ${{ steps.check_release.outputs.missing == 'true' }}
         id: create_release
         uses: ncipollo/release-action@v1.14.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag: "${{ steps.read-version.outputs.tag }}"
           name: Changelog Enforcer ${{ steps.read-version.outputs.version }}
           body: ${{ steps.changelog_reader.outputs.changes }} 
           draft: false
           prerelease: false
-          token: ${{ env.GITHUB_TOKEN }}
 
       - name: update major version tag
         if: ${{ steps.check_release.outputs.missing == 'true' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [UNRELEASED]
+### Changed
+- Fix Github Actions Annotations ([#???](https://github.com/dangoslen/changelog-enforcer/pull/???))
 
 ## [v3.6.0]
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [UNRELEASED]
 ### Changed
-- Fix Github Actions Annotations ([#???](https://github.com/dangoslen/changelog-enforcer/pull/???))
+- Fix Github Actions Annotations ([#281](https://github.com/dangoslen/changelog-enforcer/pull/281))
 
 ## [v3.6.0]
 ### Changed


### PR DESCRIPTION
This pull request fixes the following annotations:
![grafik](https://github.com/dangoslen/changelog-enforcer/assets/30803034/bb4695e3-0e13-4c02-ba7f-7134f2fbfc73)

I moved to another action for creating the release as `actions/create-release` is archived (`This repository has been archived by the owner on Mar 4, 2021. It is now read-only.`). I also tested that in my fork by just inverting the if of the create-release job. Check https://github.com/Wissididom/changelog-enforcer/actions/runs/7870238132/job/21471131168?pr=2 for my test workflow.

To fix `Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: mindsers/changelog-reader-action@v2, actions/create-release@v1.1.4. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.` (or `Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: mindsers/changelog-reader-action@v2. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.` after the changes introduced with this PR) `mindsers/changelog-reader-action` would need to update their action first.